### PR TITLE
Redirect to Wikipedia desktop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Milliseconds to delay the promise.
 
 ### What is yocto?
 
-[It's the smallest official unit prefix in the metric system.](https://en.m.wikipedia.org/wiki/Yocto-) Much smaller than nano.
+[It's the smallest official unit prefix in the metric system.](https://en.wikipedia.org/wiki/Yocto-) Much smaller than nano.
 
 ### Is this a joke?
 


### PR DESCRIPTION
On mobile you will still be automatically redirected to wikipedia mobile.

Merge asap, this bug can potentially lead to left-pad levels of disruption in production servers.